### PR TITLE
towards python 2+3 dual compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,10 +12,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+from __future__ import division, print_function
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-print os.path.abspath('..')
+print(os.path.abspath('..'))
 import matplotlib
 matplotlib.use('Agg')
 

--- a/examples/WDM_splitter/WDM_splitter.py
+++ b/examples/WDM_splitter/WDM_splitter.py
@@ -1,5 +1,6 @@
 ######## IMPORTS ########
 # General purpose imports
+from __future__ import division, print_function
 import numpy as np
 from lumopt.optimization import Super_Optimization, Optimization
 from lumopt.geometries.polygon import function_defined_Polygon

--- a/examples/Ysplitter/robust_coupler.py
+++ b/examples/Ysplitter/robust_coupler.py
@@ -1,5 +1,6 @@
 ######## IMPORTS ########
 # General purpose imports
+from __future__ import division, print_function
 import numpy as np
 from lumopt.optimization import Super_Optimization, Optimization
 from lumopt.geometries.polygon import function_defined_Polygon

--- a/examples/Ysplitter/splitter_opt_2D.py
+++ b/examples/Ysplitter/splitter_opt_2D.py
@@ -1,5 +1,6 @@
 ######## IMPORTS ########
 # General purpose imports
+from __future__ import division, print_function
 import numpy as np
 import os
 import scipy

--- a/examples/Ysplitter/splitter_opt_3D.py
+++ b/examples/Ysplitter/splitter_opt_3D.py
@@ -1,5 +1,6 @@
 ######## IMPORTS ########
 # General purpose imports
+from __future__ import division, print_function
 import numpy as np
 import os
 import scipy

--- a/examples/crossing/cross_opt.py
+++ b/examples/crossing/cross_opt.py
@@ -1,4 +1,5 @@
 ######## IMPORTS ########
+from __future__ import division, print_function
 import numpy as np
 
 from lumopt.figures_of_merit.modematch import ModeMatch

--- a/examples/grating/grating_opt.py
+++ b/examples/grating/grating_opt.py
@@ -29,7 +29,7 @@ n_grates=22
 def grate_function_generator(grate_number,grate_height=70e-9,grate_center_y=220e-9-35e-9):
     def grate_function(params):
         grate_position=params[grate_number]
-        grate_width=params[grate_number+len(params)/2]
+        grate_width=params[grate_number+int(len(params)/2)]
         left=grate_position-grate_width/2
         right=grate_position+grate_width/2
         top=grate_center_y+grate_height/2

--- a/examples/grating/grating_opt.py
+++ b/examples/grating/grating_opt.py
@@ -1,6 +1,7 @@
 
 ######## IMPORTS ########
 # General purpose imports
+from __future__ import division, print_function
 import numpy as np
 import os
 import scipy

--- a/examples/grating/grating_opt_continuous_index.py
+++ b/examples/grating/grating_opt_continuous_index.py
@@ -1,6 +1,6 @@
-
 ######## IMPORTS ########
 # General purpose imports
+from __future__ import division, print_function
 import numpy as np
 import os
 import scipy
@@ -20,8 +20,8 @@ from lumopt.utilities.materials import Material
 script = load_from_lsf(os.path.join(CONFIG['root'], 'examples/grating/grating_base_continuous.lsf'))
 
 ######## DEFINE OPTIMIZABLE GEOMETRY ########
-x_points=18000/20
-y_points=220/20
+x_points=int(18000/20)
+y_points=int(220/20)
 
 eps=np.ones((x_points,y_points))*3.4**2
 geometry = ContinousEpsilon2D(eps=eps,x=np.linspace(0,18e-6,x_points),y=np.linspace(0,0.22e-6,y_points))

--- a/lumopt/__init__.py
+++ b/lumopt/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import inspect, os
 import pathlib
 
@@ -7,6 +8,6 @@ root=pathlib.Path(*here.parts[:-1])
 CONFIG={}
 #CONFIG['fdtd_path']="/Applications/Lumerical/FDTD Solutions/FDTD Solutions.app/Contents/API/Python"
 CONFIG['root']=str(root.absolute())
-print 'CONFIGURATION FILE {}'.format(CONFIG)
+print('CONFIGURATION FILE {}'.format(CONFIG))
 
 ## Geeze this seems awefully complicated, is there no other way to do it better??

--- a/lumopt/figures_of_merit/field_intensities.py
+++ b/lumopt/figures_of_merit/field_intensities.py
@@ -1,5 +1,6 @@
+from __future__ import division, print_function
 import lumopt.lumerical_methods.lumerical_scripts as ls
-from fom import fom
+from lumopt.figures_of_merit.fom import fom
 import numpy as np
 import lumapi
 
@@ -46,7 +47,7 @@ class FieldIntensity(fom):
         field = self.fields
         pointfield = field.getfield(field.x[0], field.y[0], field.z[0], self.wavelengths[0])
 
-        # print prefactor
+        # print(prefactor)
         adjoint_source = np.conj(pointfield)
 
         ls.add_dipole(sim.fdtd, field.x[0], field.y[0], field.z[0], self.wavelengths[0], adjoint_source)
@@ -122,7 +123,7 @@ class FieldIntensities(fom):
 
 
         prefactor=1#eps0#*omega
-        #print prefactor
+        #print(prefactor)
         if self.weight_amplitudes is None:
             adjoint_sources=[prefactor*np.conj(pointfield) for pointfield in pointfields]
         else:

--- a/lumopt/figures_of_merit/fom.py
+++ b/lumopt/figures_of_merit/fom.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import lumopt.lumerical_methods.lumerical_scripts as ls
 from numpy import conj,pi
 

--- a/lumopt/figures_of_merit/modematch.py
+++ b/lumopt/figures_of_merit/modematch.py
@@ -1,8 +1,9 @@
+from __future__ import division, print_function
 import lumopt.lumerical_methods.lumerical_scripts as ls
 import numpy as np
 from lumopt import CONFIG
 import sys
-from fom import fom
+from lumopt.figures_of_merit.fom import fom
 from lumopt.utilities.fields import Fields
 
 
@@ -157,9 +158,9 @@ if __name__ == '__main__':
     # # calculate the gradient using the adjoint solve
     # opt.run_adjoint_solves()
     # calculated_gradients = np.array(opt.calculate_gradients())
-    # print calculated_gradients
+    # print(calculated_gradients)
     # n_derivatives = 4
     # finite_difference_gradients = opt.calculate_finite_differences_gradients(n_derivatives=n_derivatives, dx=5e-9,
     #                                                                          central=True, print_res=True)
     #
-    # print finite_difference_gradients
+    # print(finite_difference_gradients)

--- a/lumopt/figures_of_merit/modematch_dipoles_legacy.py
+++ b/lumopt/figures_of_merit/modematch_dipoles_legacy.py
@@ -1,10 +1,11 @@
+from __future__ import division, print_function
 import lumopt.lumerical_methods.lumerical_scripts as ls
 from numpy import conj, pi
 import numpy as np
 from lumopt import CONFIG
 import sys
 from lumopt.figures_of_merit.field_intensities import FieldIntensities
-from fom import fom
+from lumopt.figures_of_merit.fom import fom
 from lumopt.utilities.fields import Fields
 
 
@@ -299,7 +300,7 @@ class ModeMatch3(ModeMatch2):
         pointfields=[fields.getfield(pos[0],pos[1],pos[2],self.wavelength) for pos in self.positions]
 
         prefactor=1#eps0#*omega
-        #print prefactor
+        #print(prefactor)
         sum_of_pointfields=sum([pointfield*phase_factor for pointfield,phase_factor in zip(pointfields,self.phase_factors)])
         prefactor=np.conj(sum_of_pointfields)
         adjoint_sources=[prefactor*phase_factor for phase_factor in self.phase_factors]

--- a/lumopt/geometries/continuous_epsilon.py
+++ b/lumopt/geometries/continuous_epsilon.py
@@ -1,4 +1,5 @@
-from geometry import Geometry
+from __future__ import division, print_function
+from lumopt.geometries.geometry import Geometry
 from lumopt.utilities.materials import Material
 import lumapi
 import numpy as np
@@ -57,9 +58,9 @@ class ContinousEpsilon2D(Geometry):
         for x in self.x:
             for y in self.y:#,y in zip(xx.reshape(-1),yy.reshape(-1)):
                 derivs.append(gradient_fields.integrate_square(center=(x,y),box=(dx,dy),z=self.z,wl=wavelength,real=real))
-            print '.',
-        print ''
-        print 'Done'
+            print('.', end=' ')
+        print()
+        print('Done')
         return derivs
 
     def initialize(self,wavelengths,opt):
@@ -581,4 +582,4 @@ if __name__=='__main__':
     y_geo=opt.geometry.y
 
 
-    print 'ha'
+    print('ha')

--- a/lumopt/geometries/geometry.py
+++ b/lumopt/geometries/geometry.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 import lumapi
 import lumopt.lumerical_methods.lumerical_scripts as ls
@@ -104,14 +105,14 @@ class Geometry(object):
         current_eps=self.get_eps()[0]
         current_params=self.get_current_params()
         d_epses=[]
-        print 'Getting d eps'
+        print('Getting d eps')
         for i,param in enumerate(current_params):
             d_params = current_params.copy()
             d_params[i] = param + dx
             d_eps=(self.get_eps(d_params)[0]-current_eps)/dx
             d_epses.append(d_eps)
-            print(','),
-        print('')
+            print(',', end=' ')
+        print()
         return d_epses
 
     def get_d_eps_d_params_update(self,dx):
@@ -119,7 +120,7 @@ class Geometry(object):
         current_eps, x, y, z, sim = self.get_eps(return_sim=True)
         current_params=self.get_current_params()
         d_epses=[]
-        print 'Getting d eps'
+        print('Getting d eps')
         for i,param in enumerate(current_params):
             d_params = current_params.copy()
             d_params[i] = param + dx

--- a/lumopt/geometries/polygon.py
+++ b/lumopt/geometries/polygon.py
@@ -1,4 +1,5 @@
-from geometry import Geometry
+from __future__ import division, print_function
+from lumopt.geometries.geometry import Geometry
 import numpy as np
 from lumopt.utilities.edge import Edge
 import scipy
@@ -74,8 +75,8 @@ class Polygon(Geometry):
         gradient_pairs_edges=[]
         for edge in self.edges:
             gradient_pairs_edges.append(edge.derivative(gradient_fields,wavelength,n_points=self.edge_precision,real=real))
-            print '.',
-        print ''
+            print('.',end=' ')
+        print()
         #the gradients returned for an edge derivative are the gradients with respect to moving each end point perpendicular to that edge
         #This is not exactly what we are looking for here, since we want the derivative w/ respect to moving each point
         #in the x or y direction, so coming up is a lot of projections...

--- a/lumopt/lumerical_methods/lumerical_scripts.py
+++ b/lumopt/lumerical_methods/lumerical_scripts.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 from lumopt.utilities.fields import Fields, FieldsNoInterp
 import numpy as np
 
@@ -44,7 +45,7 @@ def get_fields_no_interp(fdtd, monitor_name, get_eps=False, get_D=False, get_H=F
     For the fields used to create gradients, the D component of the field and the refractive index also need to be fetched.
     For the fields on figure of merit monitors, D  or index does not need to be fetched
     It returns a Field object'''
-    #print 'getting raw fields for {}'.format(monitor_name)
+    #print('getting raw fields for {}'.format(monitor_name))
     # script="m='{}';".format(monitor_name)
     # script+="x = getdata(m,'x');"\
     #         "y = getdata(m,'y');"\
@@ -114,7 +115,7 @@ def get_fields_interp(fdtd, monitor_name, get_eps=False, get_D=False, get_H=Fals
     For the fields used to create gradients, the D component of the field and the refractive index also need to be fetched.
     For the fields on figure of merit monitors, D  or index does not need to be fetched
     It returns a Field object'''
-    #print 'getting interpolated fields for {}'.format(monitor_name)
+    #print('getting interpolated fields for {}'.format(monitor_name))
     fields = fdtd.getresult(monitor_name,'E')
     fields_eps = fdtd.getresult(monitor_name + '_D_index','eps')['eps'] if get_eps else None
     fields_D = fdtd.getresult(monitor_name + '_D_index','D')['D'] if get_D else None
@@ -219,7 +220,7 @@ def copy_properties(fdtd,origin,destination,properties= ['x', 'y', 'z', 'x_span'
         try:
             dest.__setattr__(thing.replace(' ','_'), orig.__getattr__(thing.replace(' ','_')))
         except:
-            print 'Could not copy {} from {} to {} '.format(thing,origin,destination)
+            print('Could not copy {} from {} to {} '.format(thing,origin,destination))
 
 def set_injection_axis(fdtd,source_name):
     src = fdtd.getObjectById(source_name)

--- a/lumopt/optimization.py
+++ b/lumopt/optimization.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 from lumopt.lumerical_methods.lumerical_scripts import add_D_monitors_to_fields_monitors, \
     remove_interpolation_on_monitor, add_index_to_fields_monitors, set_spatial_interp
 from lumopt.utilities.simulation import Simulation
@@ -245,7 +246,7 @@ class Optimization(Super_Optimization):
         '''
 
         if self.verbose:
-            print 'Running Forward Solves'
+            print('Running Forward Solves')
 
         # create the simulation
         forward_sim = self.make_sim()
@@ -271,7 +272,7 @@ class Optimization(Super_Optimization):
         Generates the adjoint simulations, runs them and extacts the adjoint fields
         '''
         if self.verbose:
-            print 'Running adjoint Solves'
+            print('Running adjoint Solves')
 
         adjoint_sim = self.make_sim()
 
@@ -290,7 +291,7 @@ class Optimization(Super_Optimization):
         Generates the adjoint simulations, moslty for testing
         '''
         if self.verbose:
-            print 'Running adjoint Solves'
+            print('Running adjoint Solves')
 
         adjoint_sim = self.make_sim()
 
@@ -338,7 +339,7 @@ class Optimization(Super_Optimization):
         self.run_forward_solves()
         self.run_adjoint_solves()
         adjoint_gradients=self.calculate_gradients(real=False)
-        print "Adjoint gradients= {}".format(adjoint_gradients)
+        print("Adjoint gradients= {}".format(adjoint_gradients))
         current_fom = self.fomHist[-1]
         current_eps = deepcopy(self.forward_fields.eps.copy())
         current_E = deepcopy(self.forward_fields.E)
@@ -360,17 +361,17 @@ class Optimization(Super_Optimization):
                 plt.pcolormesh(np.real(d_eps[:, :, 0, 0, 2]).transpose())
                 plt.show()
                 recalculated_adjoint_deriv = trapz3D(np.sum(sparse_pert_E*d_eps,axis=-1)[:,:,:,0],self.forward_fields.x,self.forward_fields.y,self.forward_fields.z)
-                print 'recalculated adjoint gradients={}'.format(recalculated_adjoint_deriv)
+                print('recalculated adjoint gradients={}'.format(recalculated_adjoint_deriv))
                 recalculated_adjoint_derivs.append(recalculated_adjoint_deriv)
             else:
-                print 'central not supported on this on yet'
+                print('central not supported on this on yet')
 
             if print_res: print('Derivative n {}={}'.format(i, deriv))
         self.geometry.update_geometry(params)
 
         if print_res:
-            print finite_differences_gradients
-            print recalculated_adjoint_derivs
+            print(finite_differences_gradients)
+            print(recalculated_adjoint_derivs)
 
         return finite_differences_gradients, recalculated_adjoint_derivs,adjoint_gradients
 
@@ -435,7 +436,7 @@ class Optimization(Super_Optimization):
                 self.geometry.update_geometry(params)
 
         if print_res:
-            print finite_differences_gradients
+            print(finite_differences_gradients)
 
         return finite_differences_gradients
 
@@ -444,7 +445,7 @@ class Optimization(Super_Optimization):
         '''Uses the forward and adjoint fields to calculate the derivatives to the optimization parameters
             Assumes the forward and adjoint solves have been run'''
         if self.verbose:
-            print 'Calculating Gradients'
+            print('Calculating Gradients')
 
         # Create the gradient fields
         self.gradient_fields = Gradient_fields(forward_fields=self.forward_fields, adjoint_fields=self.adjoint_fields)
@@ -470,7 +471,7 @@ class Optimization(Super_Optimization):
                 return inspect.stack()[num]  # 1 is get_caller's caller
             calling_file= os.path.abspath(inspect.getfile(get_caller(3)[0]))
         except:
-            print 'Couldnt copy python setupfile'
+            print('Couldnt copy python setupfile')
 
 
         directories = os.listdir(os.getcwd())
@@ -480,7 +481,7 @@ class Optimization(Super_Optimization):
             old = - 1
 
         if old == 25:
-            print 'Too many optimization folders in {}'.format(os.getcwd())
+            print('Too many optimization folders in {}'.format(os.getcwd()))
             raise ValueError
 
         new_dir_name = 'opts_{}'.format(old + 1)

--- a/lumopt/optimizers/generic_optimizers.py
+++ b/lumopt/optimizers/generic_optimizers.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 import scipy.optimize as sci
 import copy
@@ -301,7 +302,7 @@ class ScipyOptimizers(Optimizer):
 
     def run(self,verbose=True):
         print('Running Scipy Optimizer')
-        print 'bounds= {}'.format(self.bounds)
-        print 'start= {}'.format(self.start_point)
+        print('bounds= {}'.format(self.bounds))
+        print('start= {}'.format(self.start_point))
         res= sci.minimize(fun=self.callable_fom,x0=self.start_point,jac=self.callable_jac,bounds=self.bounds,callback=self.callback,options={'maxiter':self.max_iter,'disp':True,'gtol':self.pgtol},method=self.method)
         return res

--- a/lumopt/optimizers/placeholder.py
+++ b/lumopt/optimizers/placeholder.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 
 class placeholder_optimizer(object):
 

--- a/lumopt/utilities/edge.py
+++ b/lumopt/utilities/edge.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 from lumopt.utilities.scipy_wrappers import trapz1D,trapz3D,trapz2D
 

--- a/lumopt/utilities/fields.py
+++ b/lumopt/utilities/fields.py
@@ -2,6 +2,7 @@
 
 
 
+from __future__ import division, print_function
 import matplotlib as mpl
  #mpl.use('TkAgg')
 
@@ -150,7 +151,7 @@ class Fields(object):
         '''Calculates the mode overlap with another field. This assumes this mode has been normalized'''
         if not self.normalized:
             self.normalize_power()
-            print 'Normalized the mode being modematched to'
+            print('Normalized the mode being modematched to')
 
         if not (len(self.x)==len(other_field.x) and len(self.y)==len(other_field.y) and len(self.z)==len(other_field.z) and len(self.wl)==len(other_field.wl)):
             raise ValueError('Fields are not on same grid, (or not the same amount of wavelengths Modematch does not support this (write a method!!)')

--- a/lumopt/utilities/gradients.py
+++ b/lumopt/utilities/gradients.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 from scipy.integrate import dblquad,nquad
 from lumopt.utilities.scipy_wrappers import dblsimps, wrapped_GridInterpolator
@@ -50,7 +51,7 @@ class Gradient_fields(object):
         :returns: gradient_field(x,y,z,wl), a function that returns the derivative of the fom wrt epsilon in space'''
 
         def gradient_field(x,y,z,wl,real=True):
-            #print 'x={} y={}'.format(x,y)
+            #print('x={} y={}'.format(x,y))
             if real:
                 return sum(2*eps0* np.real(self.forward_fields.getfield(x,y,z,wl)*self.adjoint_fields.getfield(x,y,z,wl))) #Eq 5.28 of O. Miller's thesis
             else:

--- a/lumopt/utilities/load_lumerical_scripts.py
+++ b/lumopt/utilities/load_lumerical_scripts.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 def load_from_lsf(script_file_name):
     '''
     A very simple function that can load an lsf file and reformats it to work with this code.

--- a/lumopt/utilities/load_lumerical_scripts.py
+++ b/lumopt/utilities/load_lumerical_scripts.py
@@ -8,7 +8,7 @@ def load_from_lsf(script_file_name):
     :return:
     '''
 
-    with open(script_file_name, 'rb') as text_file:
+    with open(script_file_name, 'r') as text_file:
         lines = [line.strip().split('#',1)[0] for line in text_file.readlines()]
 
     script=""

--- a/lumopt/utilities/materials.py
+++ b/lumopt/utilities/materials.py
@@ -1,4 +1,5 @@
 
+from __future__ import division, print_function
 from lumopt import CONFIG
 
 import sys
@@ -85,5 +86,5 @@ class Material(object):
 if __name__=='__main__':
     test=Material()
     test.initialize()
-    print test.permittivities
-    print test.get_eps(1550e-9)
+    print(test.permittivities)
+    print(test.get_eps(1550e-9))

--- a/lumopt/utilities/plotter.py
+++ b/lumopt/utilities/plotter.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import matplotlib as mpl
 
 # #mpl.use('TkAgg')
@@ -45,13 +46,13 @@ class Plotter(object):
                 try:
                     optimization.optimizations[0].gradient_fields.plot_eps(self.ax[1,0])
                 except:
-                    print "can't plot geometry"
+                    print("can't plot geometry")
             try:
                 optimization.optimizations[0].gradient_fields.plot(self.fig,self.ax[1,1],self.ax[1,2])
             except:
-                print "can't plot gradient fields"
+                print("can't plot gradient fields")
             # optimization.optimizations[0].geometry.plot(self.ax[1,0])
-        print 'plot updated'
+        print('plot updated')
         plt.tight_layout()
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()

--- a/lumopt/utilities/scipy_wrappers.py
+++ b/lumopt/utilities/scipy_wrappers.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 from scipy.interpolate import RegularGridInterpolator
 import numpy as np
 
@@ -143,28 +144,28 @@ def demo_interpolator():
     points = (np.array([3, 4]), np.array([1, 2]),np.array([5]))
     vals = np.array([10,11,12,13]).reshape(2,2,1)
 
-    print vals.shape
+    print(vals.shape)
     wi=wrapped_GridInterpolator(points,vals)
 
-    print wi((3.5,1.5,5))
-    print wi((3.5, 1, 5))
-    print wi([(3.5,1.5,5),(3.5,1,5)])
+    print(wi((3.5,1.5,5)))
+    print(wi((3.5, 1, 5)))
+    print(wi([(3.5,1.5,5),(3.5,1,5)]))
 
     points=(np.array([1]),np.array([2]))
     vals=np.array([5]).reshape(1,1)
 
     wi = wrapped_GridInterpolator(points, vals)
 
-    print wi((1, 2))
+    print(wi((1, 2)))
 
     ti=RegularGridInterpolator(points,vals)
     try:
-        print ti((3.5,1.5,5))
+        print(ti((3.5,1.5,5)))
     except:
-        print 'It didnt work for the regular interpolator!'
+        print('It didnt work for the regular interpolator!')
 
 if __name__=='__main__':
     demo_interpolator()
     import os
-    print os.getcwd()
-    print dblsimps(lambda x, y:x * y, 0, 10, -2, 2,points_per_dimension=3)
+    print(os.getcwd())
+    print(dblsimps(lambda x, y:x * y, 0, 10, -2, 2,points_per_dimension=3))

--- a/lumopt/utilities/simulation.py
+++ b/lumopt/utilities/simulation.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 from lumopt import CONFIG
 import sys
 


### PR DESCRIPTION
In case you're interested...

I tried not to change anything whatsoever about the Python 2 functionality (but sorry if I introduced any bugs).

For Python 3, it's probably not going to work yet, but after this change it would at least be a lot closer. (e.g. there may be strings / bytes / unicode issues.)

(I didn't and can't test this code myself ... still waiting for a Lumerical API license.)

SPECIFIC CHANGES:

* I put in `from __future__ import division, print_function` in every non-blank Python file
* `print x` --> `print(x)` throughout
* I could only find one floor integer division (in grating_opt_continuous_index) and I put in an `int(...)` to keep it behaving the same as before. I think every other division in the codebase is float division, so not affected by the `from __future__ import division` directive. (If any other floor-integer-division is happening, I think it's by accident, or else I missed it.)
* Almost all the module imports were already absolute imports that work in both Python 2+3. But there were a couple "implicit relative imports", which I converted to absolutes.