### PR TITLE
Fix added geometry parameters

### DIFF
--- a/lumopt/geometries/geometry.py
+++ b/lumopt/geometries/geometry.py
@@ -63,7 +63,7 @@ class Geometry(object):
         if self.operation=='mul':
             return params1
         if self.operation=='add':
-            return params1+np.array(self.geometries[1].get_current_params())
+            return np.concatenate(params1,np.array(self.geometries[1].get_current_params()) )
 
     def plot(self,*args):
         return False

--- a/lumopt/geometries/geometry.py
+++ b/lumopt/geometries/geometry.py
@@ -63,7 +63,8 @@ class Geometry(object):
         if self.operation=='mul':
             return params1
         if self.operation=='add':
-            return np.concatenate(params1,np.array(self.geometries[1].get_current_params()) )
+            return np.concatenate(( params1,
+                                    np.array(self.geometries[1].get_current_params()) ))
 
     def plot(self,*args):
         return False


### PR DESCRIPTION
Error in Geometry.get_current_params when self.operation=='add'. Returned the sum of independent parameters. Fixed to return a concatentation of parameters.